### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,8 +1,8 @@
 class DeliveryFee < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
-    { id: 2, name: '着払い（購入者負担' },
-    { id: 3, name: '送料込み（出品者負担' }
+    { id: 2, name: '着払い（購入者負担)' },
+    { id: 3, name: '送料込み（出品者負担)' }
   ]
 
   include ActiveHash::Associations

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,36 +127,38 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% if @items.present? %>
+        <li class='list'>
+        <% @items.each do |item| %>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <%# <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> %>
+                <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <%end%>  
+        </li>
+      <% end %>  
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% if @items.empty? %> 
         <li class='list'>
           <%= link_to '#' do %>
@@ -176,8 +178,6 @@
           <% end %>
         </li>
       <% end %> 
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -157,23 +157,25 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @items.empty? %> 
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %> 
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Category Select')
       end
 
-      it 'カテゴリーの情報は１を選択すると出品できないこと' do 
+      it 'カテゴリーの情報は１を選択すると出品できないこと' do
         @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Category Select')
-      end 
+      end
 
       it '商品の状態についての情報が存在しなければ出品できないこと' do
         @item.condition_id = ''
@@ -49,7 +49,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Condition Select')
       end
 
-      it '商品の状態についての情報は１を選択すると出品できないこと' do 
+      it '商品の状態についての情報は１を選択すると出品できないこと' do
         @item.condition_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Condition Select')
@@ -61,7 +61,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Delivery fee Select')
       end
 
-      it '配送料の負担についての情報は１を選択すると出品できないこと' do 
+      it '配送料の負担についての情報は１を選択すると出品できないこと' do
         @item.delivery_fee_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Delivery fee Select')
@@ -73,7 +73,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Prefecture Select')
       end
 
-      it '発送元の地域についての情報は１を選択すると出品できないこと' do 
+      it '発送元の地域についての情報は１を選択すると出品できないこと' do
         @item.prefecture_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Prefecture Select')
@@ -85,11 +85,11 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Days to ship Select')
       end
 
-      it '発送までの日数についての情報は１を選択すると出品できないこと' do 
+      it '発送までの日数についての情報は１を選択すると出品できないこと' do
         @item.days_to_ship_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Days to ship Select')
-      end     
+      end
 
       it '販売価格が300円未満だと出品できないこと' do
         @item.price = 299
@@ -98,7 +98,7 @@ RSpec.describe Item, type: :model do
       end
 
       it '販売価格が9,999,999円より高いと出品できないこと' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
@@ -110,13 +110,13 @@ RSpec.describe Item, type: :model do
       end
 
       it '販売価格が半角英数混合だと出品できないこと' do
-        @item.price = "abc123"
+        @item.price = 'abc123'
         @item.valid?
         expect(@item.errors.full_messages).to include('Price Half-width number')
       end
 
       it '販売価格が半角英語のみだと出品できないこと' do
-        @item.price = "abcdef"
+        @item.price = 'abcdef'
         @item.valid?
         expect(@item.errors.full_messages).to include('Price Half-width number')
       end


### PR DESCRIPTION
# What 
 - トップページへ商品一覧を表示
 - 表示順は新しい商品が上になるよう並び替え
 - 商品が出品されていない状態ではダミーの商品を表示

# Why
 商品一覧表示機能実装のため

- 商品のデータがない場合には、ダミー商品が表示されている動画
　https://gyazo.com/b4964c843a9c00bde8408cd13514bf57

- 商品のデータがある場合は、商品が一覧で表示されている動画
　https://gyazo.com/8a60d3a97754de630cce43818f60890e